### PR TITLE
Refactor

### DIFF
--- a/handler/Makefile
+++ b/handler/Makefile
@@ -24,10 +24,12 @@ else ifeq ($(strip $(CIRCLE_TAG)),)
 	@echo "CIRCLE_TAG must be set"
 	@exit 0
 else ifeq ($(shell echo $(CIRCLE_TAG) | egrep '^v\d+\.\d+\.\d+'),)
-	@echo "CIRCLE_TAG must match version pattern (i.e. v.1.2.3)"
+	@echo "CIRCLE_TAG must match version pattern (i.e. v1.2.3)"
 	@exit 0
-else
+else ifeq ($(CIRCLE_BRANCH), "master")
 	ghr -u $(CIRCLE_PROJECT_USERNAME) -r $(CIRCLE_PROJECT_REPONAME) -c $(CIRCLE_SHA1) -n $(CIRCLE_TAG) -delete $(CIRCLE_TAG) $(RELEASEDIR)
+else
+	ghr -prerelease -u $(CIRCLE_PROJECT_USERNAME) -r $(CIRCLE_PROJECT_REPONAME) -c $(CIRCLE_SHA1) -n $(CIRCLE_TAG) -delete $(CIRCLE_TAG) $(RELEASEDIR)
 endif
 
 clean:

--- a/handler/main.go
+++ b/handler/main.go
@@ -47,8 +47,8 @@ func eventHandler(ctx context.Context, logsEvent events.CloudwatchLogsEvent) {
 }
 
 // handleEvents ... parses log messages out of log events
-func handleEvents(events []interface{}, includedEventNames, excludedKeys []string) {
-	for _, logEvent := range events {
+func handleEvents(logEvents []interface{}, includedEventNames, excludedKeys []string) {
+	for _, logEvent := range logEvents {
 		log.Printf("**Event (%T): %v", logEvent, logEvent)
 
 		if mStr, ok := logEvent.(map[string]interface{})["message"]; ok {

--- a/handler/main.go
+++ b/handler/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -78,7 +79,8 @@ func eventHandler(ctx context.Context, logsEvent events.CloudwatchLogsEvent) {
 
 func parseLogDataToPayload(data string) (payload map[string]interface{}, err error) {
 	source := strings.NewReader(data)
-	encoder := base64.NewDecoder(base64.StdEncoding, &source)
+	encoder := base64.NewDecoder(base64.StdEncoding, io.Reader(source))
+
 	r, err := gzip.NewReader(encoder)
 	if err != nil {
 		log.Fatalf("error decompressing cloudwatch data: %v", err)
@@ -90,8 +92,6 @@ func parseLogDataToPayload(data string) (payload map[string]interface{}, err err
 		log.Fatalf("error reading decompressed cloudwatch data: %v", err)
 		return
 	}
-
-	payload := make(map[string]interface{})
 
 	err = json.Unmarshal(s, &payload)
 	if err != nil {

--- a/handler/main.go
+++ b/handler/main.go
@@ -1,12 +1,8 @@
 package main
 
 import (
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/json"
-	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -18,149 +14,86 @@ import (
 	"github.com/aws/aws-sdk-go/service/ses"
 )
 
+// ConsoleLoginEvent ... type for parsing event message json string
+type ConsoleLoginEvent struct {
+	EventVersion    string          `json:"eventVersion"`
+	UserIdentity    IAMUserIdentity `json:"userIdentity"`
+	EventTime       string          `json:"eventTime"`
+	EventSource     string          `json:"eventSource"`
+	EventName       string          `json:"eventName"`
+	AWSRegion       string          `json:"awsRegion"`
+	SourceIPAddress string          `json:"sourceIPAddress"`
+	UserAgent       string          `json:"userAgent"`
+	// "requestParameters": null,
+	// "responseElements": {
+	//    "ConsoleLogin": "Success"
+	// },
+	// "additionalEventData": {
+	EventID            string `json:"eventID"`
+	EventType          string `json:"eventType"`
+	RecipientAccountID string `json:"recipientAccountId"`
+}
+
+// IAMUserIdentity ... type for userIdentity in ConsoleLoginEvent
+type IAMUserIdentity struct {
+	Type string `json:"type"`
+	// *ignore* principalId string
+	// *ignore* arn string
+	AccountID string `json:"accountId"`
+	UserName  string `json:"userName"`
+}
+
 // eventHandler ... Handles log events by parsing them, filtering and sending
 //  emails for select event types
 func eventHandler(ctx context.Context, logsEvent events.CloudwatchLogsEvent) {
-	includedEventNames := []string{
-		"ConsoleLogin",
-	}
-	excludedKeys := []string{
-		"accessKeyId",
-		"principalId",
-	}
-
-	payload, err := parseLogDataToPayload(logsEvent.AWSLogs.Data)
+	data, err := logsEvent.AWSLogs.Parse()
 	if err != nil {
-		log.Fatalf("error parsing log data to payload: %v", err)
+		log.Fatalf("error parsing log data: %v", err)
 		return
 	}
 
-	log.Printf("***Payload:\n%v", payload)
-
-	logEvents, ok := payload["logEvents"].([]interface{})
-	if !ok {
-		log.Fatalf("error asserting payload[\"logEvents\"].([]interface{}")
-		return
-	}
-
-	handleEvents(logEvents, includedEventNames, excludedKeys)
+	handleEvents(data.LogEvents)
 }
 
 // handleEvents ... parses log messages out of log events
-func handleEvents(logEvents []interface{}, includedEventNames, excludedKeys []string) {
+func handleEvents(logEvents []events.CloudwatchLogsLogEvent) {
 	for _, logEvent := range logEvents {
-		log.Printf("**Event (%T): %v", logEvent, logEvent)
+		var message ConsoleLoginEvent
 
-		if mStr, ok := logEvent.(map[string]interface{})["message"]; ok {
-			log.Printf("**message (%T):\n%v", mStr, mStr)
-
-			message := make(map[string]interface{})
-
-			s, ok := mStr.(string)
-			if !ok {
-				log.Fatalf("error asserting mStr.(string)")
-				return
-			}
-
-			err := json.Unmarshal([]byte(s), &message)
-			if err != nil {
-				log.Fatalf("error unmarshalling log event message: %v", err)
-				return
-			}
-
-			handleMessage(message, includedEventNames, excludedKeys)
+		err := json.Unmarshal([]byte(logEvent.Message), &message)
+		if err != nil {
+			log.Fatalf("error unmarshalling log event message: %v", err)
+			return
 		}
+
+		handleMessage(&message)
 	}
 }
 
 // handleMessage ... filters log event messages and sends email on matches
-func handleMessage(message map[string]interface{}, includedEventNames, excludedKeys []string) {
-	if eventType, ok := message["eventName"]; ok {
-		log.Printf("eventType (%T):\n%v\n", eventType, eventType)
-
-		if contains(includedEventNames, eventType.(string)) {
-			log.Println("**matching eventType**")
-
-			body := makeBody(message, excludedKeys)
-			sendEmail(body)
-		}
+func handleMessage(message *ConsoleLoginEvent) {
+	if message.EventName == "ConsoleLogin" {
+		body := makeBody(message)
+		sendEmail(body)
 	}
-}
-
-// parseLogDataToPayload ... decodes, decompresses and parses CloudWatch log event data
-func parseLogDataToPayload(data string) (payload map[string]interface{}, err error) {
-	source := strings.NewReader(data)
-	encoder := base64.NewDecoder(base64.StdEncoding, io.Reader(source))
-
-	r, err := gzip.NewReader(encoder)
-	if err != nil {
-		log.Fatalf("error decompressing cloudwatch data: %v", err)
-		return
-	}
-
-	s, err := ioutil.ReadAll(r)
-	if err != nil {
-		log.Fatalf("error reading decompressed cloudwatch data: %v", err)
-		return
-	}
-
-	err = json.Unmarshal(s, &payload)
-	if err != nil {
-		log.Fatalf("error unmarshalling cloudwatch data to map: %v", err)
-		return nil, err
-	}
-
-	return payload, nil
-}
-
-// contains ... checks if a string is contained in an array of strings
-func contains(s []string, str string) bool {
-	for _, a := range s {
-		if a == str {
-			return true
-		}
-	}
-
-	return false
 }
 
 // makeBody ... makes a text email body from a CloudWatch log event message
-func makeBody(m map[string]interface{}, x []string) (b string) {
-	b = "This is the header *Test*\n\n"
-	b += "EventType: " + m["eventType"].(string) + "\n"
-	b += "EventId: " + m["eventID"].(string) + "\n"
-	b += "EventTime: " + m["eventTime"].(string) + "\n"
-	b += "EventName: " + m["eventName"].(string) + "\n"
-	b += "UserAgent: " + m["userAgent"].(string) + "\n"
-	b += "AWS Region: " + m["awsRegion"].(string) + "\n"
-	b += "SourceIPAddress: " + m["sourceIPAddress"].(string) + "\n"
+func makeBody(e *ConsoleLoginEvent) (b string) {
+	b += "EventType: " + e.EventType + "\n"
+	b += "EventID: " + e.EventID + "\n"
+	b += "EventTime: " + e.EventTime + "\n"
+	b += "EventName: " + e.EventName + "\n"
+	b += "UserAgent: " + e.UserAgent + "\n"
+	b += "AWS Region: " + e.AWSRegion + "\n"
+	b += "SourceIPAddress: " + e.SourceIPAddress + "\n"
 
-	if !contains(x, "userIdentity") {
-		if ui, ok := m["userIdentity"].(map[string]interface{}); ok {
-			b += "\nUserIdentity \n\n"
-			b += parseSesUserIdentity(ui, x)
-		}
-	}
+	b += "\nUserIdentity \n\n"
+	b += "Type: " + e.UserIdentity.Type + "\n"
+	b += "AccountID:" + e.UserIdentity.AccountID + "\n"
+	b += "UserName:" + e.UserIdentity.UserName + "\n"
 
 	return b
-}
-
-// parseSesUserIdentity ... recursively filters and parses UserIdentity data
-func parseSesUserIdentity(ui map[string]interface{}, x []string) (s string) {
-	for k, i := range ui {
-		switch v := i.(type) {
-		case string:
-			if !contains(x, k) {
-				s += k + ": " + v + "\n"
-			}
-		case map[string]interface{}:
-			s += parseSesUserIdentity(v, x)
-		default:
-			log.Printf("warning: Unknown UserIdentity value type: %T", v)
-		}
-	}
-
-	return s
 }
 
 // sendEmail ... Sends an email via AWS Simple Email Service (SES)
@@ -179,7 +112,7 @@ func sendEmail(b string) {
 				},
 			},
 			Subject: &ses.Content{
-				Data: aws.String(os.Getenv("SUBJECT")),
+				Data: aws.String("Testing Go Port refactor 3"),
 			},
 		},
 		Source: aws.String(os.Getenv("FROM_EMAIL")),

--- a/handler/main.go
+++ b/handler/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/base64"
@@ -78,13 +77,9 @@ func eventHandler(ctx context.Context, logsEvent events.CloudwatchLogsEvent) {
 }
 
 func parseLogDataToPayload(data string) (payload map[string]interface{}, err error) {
-	compressedPayload, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		log.Fatalf("error decoding base64 cloudwatch data: %v", err)
-		return
-	}
-
-	r, err := gzip.NewReader(bytes.NewReader(compressedPayload))
+	source := strings.NewReader(data)
+	encoder := base64.NewDecoder(base64.StdEncoding, &source)
+	r, err := gzip.NewReader(encoder)
 	if err != nil {
 		log.Fatalf("error decompressing cloudwatch data: %v", err)
 		return

--- a/handler/main.go
+++ b/handler/main.go
@@ -97,10 +97,10 @@ func makeBody(e *ConsoleLoginEvent) (b string) {
 	b += "AWS Region: " + e.AWSRegion + "\n"
 	b += "SourceIPAddress: " + e.SourceIPAddress + "\n"
 
-	b += "\nUserIdentity \n\n"
+	b += "\nUserIdentity\n\n"
 	b += "Type: " + e.UserIdentity.Type + "\n"
-	b += "AccountID:" + e.UserIdentity.AccountID + "\n"
-	b += "UserName:" + e.UserIdentity.UserName + "\n"
+	b += "AccountID: " + e.UserIdentity.AccountID + "\n"
+	b += "UserName: " + e.UserIdentity.UserName + "\n"
 
 	return b
 }

--- a/handler/main_test.go
+++ b/handler/main_test.go
@@ -57,3 +57,57 @@ func TestEventHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeBody(t *testing.T) {
+	tt := map[string]struct {
+		e        ConsoleLoginEvent
+		expected string
+	}{
+		"empty event": {
+			expected: "EventType: \nEventID: \nEventTime: \nEventName: \nUserAgent: \n" +
+				"AWS Region: \nSourceIPAddress: \n\nUserIdentity\n\nType: \nAccountID: \n" +
+				"UserName: \n",
+		},
+		"event": {
+			e: ConsoleLoginEvent{
+				EventType:       "test1",
+				EventID:         "testID",
+				EventTime:       "testTime",
+				EventName:       "testName",
+				UserAgent:       "testAgent",
+				AWSRegion:       "testRegion",
+				SourceIPAddress: "testIP",
+
+				UserIdentity: IAMUserIdentity{
+					Type:      "testType",
+					AccountID: "testID",
+					UserName:  "testName",
+				},
+			},
+			expected: `EventType: test1
+EventID: testID
+EventTime: testTime
+EventName: testName
+UserAgent: testAgent
+AWS Region: testRegion
+SourceIPAddress: testIP
+
+UserIdentity
+
+Type: testType
+AccountID: testID
+UserName: testName
+`,
+		},
+	}
+	for name, tc := range tt {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			body := makeBody(&tc.e)
+			if tc.expected != body {
+				t.Errorf("eventHandler() failed. Expected:\n%q\nGot:\n%q\n", tc.expected, body)
+			}
+		})
+	}
+}

--- a/handler/main_test.go
+++ b/handler/main_test.go
@@ -33,16 +33,22 @@ func TestEventHandler(t *testing.T) {
 			},
 			expectedErr: "",
 		},
-		/* Need to be able to mock SES service
+		"bad message": {
+			logsEvent: events.CloudwatchLogsEvent{
+				AWSLogs: events.CloudwatchLogsRawData{
+					Data: "H4sIAOTqaF4AA6tWUMrJT3ctS80rKVayUoiuVspNLS5OTE8FcpSqlWpjFWq5AICclQgkAAAA",
+				},
+			},
+			expectedErr: "unexpected end of JSON input",
+		},
 		"matching event": {
 			logsEvent: events.CloudwatchLogsEvent{
 				AWSLogs: events.CloudwatchLogsRawData{
 					Data: "H4sIAGUGaF4AA6tWUMrJT3ctS80rKVayUoiuVspNLS5OTE8FcpSqFWKUUkFSfom5qTFAkRgl5/y84vycVJ/89My8GKVapdpYhVouAJbAiGdFAAAA",
 				},
 			},
-			expectedErr: "",
+			expectedErr: "MissingRegion: could not find region configuration",
 		},
-		*/
 	}
 	for name, tc := range tt {
 		tc := tc

--- a/handler/main_test.go
+++ b/handler/main_test.go
@@ -46,6 +46,7 @@ func TestEventHandler(t *testing.T) {
 	}
 	for name, tc := range tt {
 		tc := tc
+
 		t.Run(name, func(t *testing.T) {
 			err := eventHandler(tc.ctx, tc.logsEvent)
 			if tc.expectedErr == "" && err != nil {

--- a/handler/main_test.go
+++ b/handler/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestEventHandler(t *testing.T) {
+	tt := map[string]struct {
+		ctx         context.Context
+		logsEvent   events.CloudwatchLogsEvent
+		expectedErr string
+	}{
+		"empty event": {
+			logsEvent:   events.CloudwatchLogsEvent{},
+			expectedErr: "EOF",
+		},
+		"no events": {
+			logsEvent: events.CloudwatchLogsEvent{
+				AWSLogs: events.CloudwatchLogsRawData{
+					Data: "H4sIAI0AaF4AA6tWUMrJT3ctS80rKVayUoiOVajlAgCBPI/bFAAAAA==",
+				},
+			},
+			expectedErr: "",
+		},
+		"no matching event": {
+			logsEvent: events.CloudwatchLogsEvent{
+				AWSLogs: events.CloudwatchLogsRawData{
+					Data: "H4sIADIGaF4AA6tWUMrJT3ctS80rKVayUoiuVspNLS5OTE8FcpSqFWKUUkFSfom5qTFAkRglv3zfxJLkjBilWqXaWIVaLgDh8yUHQAAAAA==",
+				},
+			},
+			expectedErr: "",
+		},
+		/* Need to be able to mock SES service
+		"matching event": {
+			logsEvent: events.CloudwatchLogsEvent{
+				AWSLogs: events.CloudwatchLogsRawData{
+					Data: "H4sIAGUGaF4AA6tWUMrJT3ctS80rKVayUoiuVspNLS5OTE8FcpSqFWKUUkFSfom5qTFAkRgl5/y84vycVJ/89My8GKVapdpYhVouAJbAiGdFAAAA",
+				},
+			},
+			expectedErr: "",
+		},
+		*/
+	}
+	for name, tc := range tt {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			err := eventHandler(tc.ctx, tc.logsEvent)
+			if tc.expectedErr == "" && err != nil {
+				t.Errorf("eventHandler() failed. Got error: %v\n", err)
+			} else if err != nil && tc.expectedErr != err.Error() {
+				t.Errorf("eventHandler() failed. Expected error: %s. Got: %v", tc.expectedErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Adds unit tests (92.9% coverage)
- Uses [`CloudwatchLogsRawData.Parse()](https://godoc.org/github.com/aws/aws-lambda-go/events#CloudwatchLogsRawData.Parse) function
- Uses Go types instead of maps
- Closes #1 