### PR TITLE
Create HTML email body (Closes #2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: Install tflint
-          command: curl -L -o /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v0.15.1/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
+          command: curl -L -o /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v0.15.4/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
       - run:
           name: Check Terraform configurations with tflint
           command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && tflint && echo "√ $m") || exit 1 ; done

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ module "grace-log-parser" {
 | env | (optional) The environment in which the script is running (development | test | production) |
 | recipients | (required) comma delimited list of AWS SES eMail recipients |
 | sender | (required) eMail address of sender for AWS SES |
-| subject | (optional) Subject Header of  Email sent notifications |
 | region | (optional) AWS region to deploy lambda function. |
 | source_arn | (required) Source ARN of Cloudtrail Log Group |
 | source_file | "(optional) full or relative path to zipped binary of lambda handler" |

--- a/handler/email.html
+++ b/handler/email.html
@@ -1,0 +1,32 @@
+<head>
+  <style>
+    table {border-collapse: collapse;}
+    td, th {border: 1px solid Black;}
+    th {background: LightGray;}
+    tr:nth-child(even) {background: #F3F3F3;}
+    tr:nth-child(odd) {background: White;}
+    .resource {background-color: RoyalBlue; color: White; font-weight: bold;}
+    .blank {background-color: White; border: none;}
+    .group {background-color: LightBlue;}
+  </style>
+</head>
+<body>
+  <h1>{{.Event.EventType}} in {{.AccountAlias}}</h1>
+  <table>
+    <tr><th colspan="2">Event Details</th></tr>
+    <tr><td>EventType</td><td>{{.Event.EventType}}</td></tr>
+    <tr><td>EventID</td><td>{{.Event.EventID}}</td></tr>
+    <tr><td>EventTime</td><td>{{.Event.EventTime}}</td></tr>
+    <tr><td>EventName</td><td>{{.Event.EventName}}</td></tr>
+    <tr><td>UserAgent</td><td>{{.Event.UserAgent}}</td></tr>
+    <tr><td>AWS Region</td><td>{{.Event.AWSRegion}}</td></tr>
+    <tr><td>SourceIPAddress</td><td>{{.Event.SourceIPAddress}}</td></tr>
+  </table>
+  &nbsp;
+  <table>
+    <tr><th colspan="2">UserIdentity</th></tr>
+    <tr><td>Type</td><td>{{.Event.UserIdentity.Type}}</td></tr>
+    <tr><td>AccountID</td><td>{{.Event.UserIdentity.AccountID}}</td></tr>
+    <tr><td>UserName</td><td>{{.Event.UserIdentity.UserName}}</td></tr>
+  </table>
+</body>

--- a/handler/email.html
+++ b/handler/email.html
@@ -2,12 +2,9 @@
   <style>
     table {border-collapse: collapse;}
     td, th {border: 1px solid Black;}
-    th {background: LightGray;}
+    th {background-color: RoyalBlue; color: White; font-weight: bold;}
     tr:nth-child(even) {background: #F3F3F3;}
     tr:nth-child(odd) {background: White;}
-    .resource {background-color: RoyalBlue; color: White; font-weight: bold;}
-    .blank {background-color: White; border: none;}
-    .group {background-color: LightBlue;}
   </style>
 </head>
 <body>

--- a/handler/main_test.go
+++ b/handler/main_test.go
@@ -135,12 +135,9 @@ func TestHtmlBody(t *testing.T) {
   <style>
     table {border-collapse: collapse;}
     td, th {border: 1px solid Black;}
-    th {background: LightGray;}
+    th {background-color: RoyalBlue; color: White; font-weight: bold;}
     tr:nth-child(even) {background: #F3F3F3;}
     tr:nth-child(odd) {background: White;}
-    .resource {background-color: RoyalBlue; color: White; font-weight: bold;}
-    .blank {background-color: White; border: none;}
-    .group {background-color: LightBlue;}
   </style>
 </head>
 <body>
@@ -185,12 +182,9 @@ func TestHtmlBody(t *testing.T) {
   <style>
     table {border-collapse: collapse;}
     td, th {border: 1px solid Black;}
-    th {background: LightGray;}
+    th {background-color: RoyalBlue; color: White; font-weight: bold;}
     tr:nth-child(even) {background: #F3F3F3;}
     tr:nth-child(odd) {background: White;}
-    .resource {background-color: RoyalBlue; color: White; font-weight: bold;}
-    .blank {background-color: White; border: none;}
-    .group {background-color: LightBlue;}
   </style>
 </head>
 <body>
@@ -224,6 +218,7 @@ func TestHtmlBody(t *testing.T) {
 			if tc.expected != body {
 				t.Errorf("eventHandler() failed. Expected:\n%q\nGot:\n%q\n", tc.expected, body)
 			}
+			t.Log(body)
 		})
 	}
 }

--- a/handler/main_test.go
+++ b/handler/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -64,7 +65,7 @@ func TestEventHandler(t *testing.T) {
 	}
 }
 
-func TestMakeBody(t *testing.T) {
+func TestTextBody(t *testing.T) {
 	tt := map[string]struct {
 		e        ConsoleLoginEvent
 		expected string
@@ -110,7 +111,116 @@ UserName: testName
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {
-			body := makeBody(&tc.e)
+			body := tc.e.textBody()
+			if tc.expected != body {
+				t.Errorf("eventHandler() failed. Expected:\n%q\nGot:\n%q\n", tc.expected, body)
+			}
+		})
+	}
+}
+
+// nolint: funlen
+func TestHtmlBody(t *testing.T) {
+	err := os.Setenv("ACCOUNT_ALIAS", "test-account-alias")
+	if err != nil {
+		t.Fatalf("Unexpected error setting ACCOUNT_ALIAS: %v\n", err)
+	}
+
+	tt := map[string]struct {
+		e        ConsoleLoginEvent
+		expected string
+	}{
+		"empty event": {
+			expected: `<head>
+  <style>
+    table {border-collapse: collapse;}
+    td, th {border: 1px solid Black;}
+    th {background: LightGray;}
+    tr:nth-child(even) {background: #F3F3F3;}
+    tr:nth-child(odd) {background: White;}
+    .resource {background-color: RoyalBlue; color: White; font-weight: bold;}
+    .blank {background-color: White; border: none;}
+    .group {background-color: LightBlue;}
+  </style>
+</head>
+<body>
+  <h1> in test-account-alias</h1>
+  <table>
+    <tr><th colspan="2">Event Details</th></tr>
+    <tr><td>EventType</td><td></td></tr>
+    <tr><td>EventID</td><td></td></tr>
+    <tr><td>EventTime</td><td></td></tr>
+    <tr><td>EventName</td><td></td></tr>
+    <tr><td>UserAgent</td><td></td></tr>
+    <tr><td>AWS Region</td><td></td></tr>
+    <tr><td>SourceIPAddress</td><td></td></tr>
+  </table>
+  &nbsp;
+  <table>
+    <tr><th colspan="2">UserIdentity</th></tr>
+    <tr><td>Type</td><td></td></tr>
+    <tr><td>AccountID</td><td></td></tr>
+    <tr><td>UserName</td><td></td></tr>
+  </table>
+</body>
+`,
+		},
+		"event": {
+			e: ConsoleLoginEvent{
+				EventType:       "test1",
+				EventID:         "testID",
+				EventTime:       "testTime",
+				EventName:       "testName",
+				UserAgent:       "testAgent",
+				AWSRegion:       "testRegion",
+				SourceIPAddress: "testIP",
+
+				UserIdentity: IAMUserIdentity{
+					Type:      "testType",
+					AccountID: "testID",
+					UserName:  "testName",
+				},
+			},
+			expected: `<head>
+  <style>
+    table {border-collapse: collapse;}
+    td, th {border: 1px solid Black;}
+    th {background: LightGray;}
+    tr:nth-child(even) {background: #F3F3F3;}
+    tr:nth-child(odd) {background: White;}
+    .resource {background-color: RoyalBlue; color: White; font-weight: bold;}
+    .blank {background-color: White; border: none;}
+    .group {background-color: LightBlue;}
+  </style>
+</head>
+<body>
+  <h1>test1 in test-account-alias</h1>
+  <table>
+    <tr><th colspan="2">Event Details</th></tr>
+    <tr><td>EventType</td><td>test1</td></tr>
+    <tr><td>EventID</td><td>testID</td></tr>
+    <tr><td>EventTime</td><td>testTime</td></tr>
+    <tr><td>EventName</td><td>testName</td></tr>
+    <tr><td>UserAgent</td><td>testAgent</td></tr>
+    <tr><td>AWS Region</td><td>testRegion</td></tr>
+    <tr><td>SourceIPAddress</td><td>testIP</td></tr>
+  </table>
+  &nbsp;
+  <table>
+    <tr><th colspan="2">UserIdentity</th></tr>
+    <tr><td>Type</td><td>testType</td></tr>
+    <tr><td>AccountID</td><td>testID</td></tr>
+    <tr><td>UserName</td><td>testName</td></tr>
+  </table>
+</body>
+`,
+		},
+	}
+	for name, tc := range tt {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			body := tc.e.htmlBody()
 			if tc.expected != body {
 				t.Errorf("eventHandler() failed. Expected:\n%q\nGot:\n%q\n", tc.expected, body)
 			}

--- a/iam.tf
+++ b/iam.tf
@@ -29,19 +29,13 @@ resource "aws_iam_policy" "self" {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "graceLogParserLogs",
+            "Sid": "graceLogParser",
             "Effect": "Allow",
             "Action": [
-                "logs:*"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "graceLogParserSES",
-            "Effect": "Allow",
-            "Action": [
-                "ses:SendEmail",
-                "ses:SendRawEmail"
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "ses:SendEmail"
             ],
             "Resource": "*"
         }

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,3 +1,5 @@
+data "aws_iam_account_alias" "current" {}
+
 resource "aws_lambda_function" "self" {
   filename         = var.source_file
   source_code_hash = filesha256(var.source_file)
@@ -8,10 +10,10 @@ resource "aws_lambda_function" "self" {
   timeout          = 500
   environment {
     variables = {
-      TO_EMAIL   = var.recipients
-      FROM_EMAIL = var.sender
-      SUBJECT    = var.subject
-      REGION     = var.region
+      TO_EMAIL      = var.recipients
+      FROM_EMAIL    = var.sender
+      ACCOUNT_ALIAS = data.aws_iam_account_alias.current.account_alias
+      REGION        = var.region
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "sender" {
   description = "(required) eMail address of sender for AWS SES"
 }
 
-variable "subject" {
-  type        = string
-  description = "(optional) Subject Header of  Email sent notifications"
-  default     = "*Test* Grace log-parsing email"
-}
-
 variable "region" {
   description = "(optional) AWS region to deploy lambda function."
   default     = "us-east-1"


### PR DESCRIPTION
- Creates HTML body (Closes #2)
![image](https://user-images.githubusercontent.com/28535705/78935574-fef09580-7a7a-11ea-868d-24ba1d7d793a.png)
- Updates tflint to v0.15.4
- Removes `subject` input
- Sets Email Subject to: "<EventType> <AccountAlias>"